### PR TITLE
Etd 126: open telemetry proof of concept

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ DIMS_HEALTHCHECK_URL=
 CONSUME_QUEUE_NAME: etd_ingested_into_alma
 PUBLISH_QUEUE_NAME: etd_ingested_into_drs
 BROKER_URL= "ampqs://un:pw@mybroker.com:5671"
+JAEGER_NAME="http://localhost:4317"
+JAEGER_SERVICE_NAME=ETD

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.11.4]
+        python-version: [3.11.3]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.11.3]
+        python-version: [3.11.4]
     runs-on: ubuntu-latest
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ celery==5.2.7
 certifi==2022.12.7
 coverage==7.2.6
 iniconfig==2.0.0
-opentelemetry-api
-opentelemetry-sdk
-opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-semantic-conventions
+opentelemetry-api==1.19.0
+opentelemetry-sdk==1.19.0
+opentelemetry-exporter-jaeger==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-semantic-conventions==0.40b0
 packaging==23.1
 pluggy==1.0.0
 project-paths==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,11 @@ celery==5.2.7
 certifi==2022.12.7
 coverage==7.2.6
 iniconfig==2.0.0
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-jaeger
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-semantic-conventions
 packaging==23.1
 pluggy==1.0.0
 project-paths==1.1.1

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -3,6 +3,14 @@ import os
 import requests
 import logging
 import etd
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import SERVICE_NAME
+import json
 
 app = Celery()
 app.config_from_object('celeryconfig')
@@ -12,23 +20,41 @@ logger = logging.getLogger('etd_alma_monitor')
 FEATURE_FLAGS = "feature_flags"
 SEND_TO_DRS_FEATURE_FLAG = "send_to_drs_feature_flag"
 
+# tracing setup
+JAEGER_NAME = os.getenv('JAEGER_NAME')
+JAEGER_SERVICE_NAME = os.getenv('JAEGER_SERVICE_NAME')
 
+resource = Resource(attributes={SERVICE_NAME: JAEGER_SERVICE_NAME})
+trace.set_tracer_provider(TracerProvider(resource=resource))
+tracer = trace.get_tracer(__name__)
+
+otlp_exporter = OTLPSpanExporter(endpoint=JAEGER_NAME, insecure=True)
+
+span_processor = BatchSpanProcessor(otlp_exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+
+@tracer.start_as_current_span("invoke_dims")
 @app.task(serializer='json', name='etd-alma-monitor-service.tasks.send_to_drs')
 def invoke_dims(json_message):
     logger.debug("message")
     logger.debug(json_message)
+    current_span = trace.get_current_span()
     dims_ingest_url = os.getenv("DIMS_INGEST_URL")
     if dims_ingest_url is not None:
         # Temporarily using a get call since we are testing
         # with a healtcheck endpoint for 'hello world'
         r = requests.get(dims_ingest_url, verify=False)
         logger.debug(r.text)
+        current_span.add_event(r.text)
+
     if FEATURE_FLAGS in json_message:
         feature_flags = json_message[FEATURE_FLAGS]
         if SEND_TO_DRS_FEATURE_FLAG in feature_flags and \
                 feature_flags[SEND_TO_DRS_FEATURE_FLAG] == "on":
             # Send to DRS
             logger.debug("FEATURE IS ON>>>>>SEND TO DRS")
+            current_span.add_event("FEATURE IS ON>>>>>SEND TO DRS")
         else:
             # Feature is off so do hello world
             return invoke_hello_world(json_message)
@@ -38,22 +64,27 @@ def invoke_dims(json_message):
 
 
 # To be removed when real logic takes its place
+@tracer.start_as_current_span("invoke_hello_world_alma_monitor")
 def invoke_hello_world(json_message):
 
     # For 'hello world', we are also going to place a
     # message onto the etd_ingested_into_drs queue
     # to allow the pipeline to continue
+    current_span = trace.get_current_span()
     new_message = {"hello": "from etd-alma-monitor-service"}
     if FEATURE_FLAGS in json_message:
         logger.debug("FEATURE FLAGS FOUND")
         logger.debug(json_message[FEATURE_FLAGS])
         new_message[FEATURE_FLAGS] = json_message[FEATURE_FLAGS]
+        current_span.add_event("FEATURE FLAGS FOUND")
+        current_span.add_event(json.dumps(json_message[FEATURE_FLAGS]))
 
     # If only unit testing, return the message and
     # do not trigger the next task.
     if "unit_test" in json_message:
         return new_message
 
+    current_span.add_event("to next queue")
     app.send_task("etd-alma-drs-holding-service.tasks.add_holdings",
                   args=[new_message], kwargs={},
                   queue="etd_ingested_into_drs")


### PR DESCRIPTION
**ETD-126: open telemetry tracing calls*
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-126


# What does this Pull Request do?
this adds tracing calls to the dash service

# How should this be tested?

first start a local version of jaeger:

` docker pull jaegertracing/all-in-one:latest`
then
`docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
  -e COLLECTOR_OTLP_ENABLED=true \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 4317:4317 \
  -p 4318:4318 \
  -p 14250:14250 \
  -p 14268:14268 \
  -p 14269:14269 \
  -p 9411:9411 \
  jaegertracing/all-in-one:latest`

then set the "JAEGER_NAME" in your local .env file to "http://YOUR-LOCAL-IP:4317/"
start the container.  enter it and run `pytest`.
then go to http://localhost:16686/  .  you should see traces from the app in the dashboard.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
