### PR TITLE
etd-206 proquest id

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -93,6 +93,10 @@ def invoke_dims(json_message):
             as current_span:
         logger.debug("message")
         logger.debug(json_message)
+        if 'identifier' in json_message:
+            proquest_identifier = json_message['identifier']
+            current_span.set_attribute("identifier", proquest_identifier)
+            logger.debug("processing id: " + str(proquest_identifier))
         dims_ingest_url = os.getenv("DIMS_INGEST_URL")
         if dims_ingest_url is not None:  # pragma: no cover, this should be checked in the healthcheck # noqa: E501
             # Temporarily using a get call since we are testing
@@ -125,6 +129,11 @@ def invoke_hello_world(json_message):
     # to allow the pipeline to continue
     current_span = trace.get_current_span()
     new_message = {"hello": "from etd-alma-monitor-service"}
+    if 'identifier' in json_message:
+        proquest_identifier = json_message['identifier']
+        new_message["identifier"] = proquest_identifier
+        current_span.set_attribute("identifier", proquest_identifier)
+        logger.debug("processing id: " + str(proquest_identifier))
     if FEATURE_FLAGS in json_message:
         logger.debug("FEATURE FLAGS FOUND")
         logger.debug(json_message[FEATURE_FLAGS])

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -10,12 +10,17 @@ class TestTasksClass():
                 'dash_feature_flag': "off",
                 'alma_feature_flag': "off",
                 'send_to_drs_feature_flag': "off",
-                'drs_holding_record_feature_flag': "off"}}
+                'drs_holding_record_feature_flag': "off"},
+                "identifier": "30522803"}
         retval = tasks.invoke_dims(message)
         assert "hello" in retval
         assert "feature_flags" in retval
+        assert "identifier" in retval
+        assert retval["identifier"] == "30522803"
 
     def test_invoke_dims_no_feature_flag(self):
-        message = {"unit_test": "true"}
+        message = {"unit_test": "true", "identifier": "30522803"}
         retval = tasks.invoke_dims(message)
         assert "hello" in retval
+        assert "identifier" in retval
+        assert retval["identifier"] == "30522803"


### PR DESCRIPTION
**Trace on ProQuest ID**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-206

# What does this Pull Request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.
Adds ProQuest ID to traces

# How should this be tested?

this has been deployed to dev.
to test on dev:
1) run the itest https://ltsds-cloud-dev-1.lib.harvard.edu:10610/integration
2) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

to test locally:
1) run pytest unit test to validate method
or
1) set up all containers locally including itest
2) run itest locally (http://localhost:16686/)
3) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
