### PR TITLE
Use HUL.TEST for int testing

### DIFF
--- a/etd/alma_monitor.py
+++ b/etd/alma_monitor.py
@@ -265,14 +265,19 @@ class AlmaMonitor():
 
     def __build_base_json_dims_data(self, mets_extractor, alma_id,
                                     record, data_dir): # pragma: no cover, covered in integration testing # noqa
-        # Use schools.py to pull owner code, billing code,
-        # and urnAuthorityPath
-        owner_code = schools.school_info[
-            record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['owner_code']
-        billing_code = schools.school_info[
-            record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['billing_code']
-        urn_authority_path = schools.school_info[
-            record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['urn_authority_path']
+        if "integration_test" in record:
+            owner_code = "HUL.TEST"
+            billing_code = "HUL.TEST.BILL_0001"
+            urn_authority_path = "HUL.TEST"
+        else:    
+            # Use schools.py to pull owner code, billing code,
+            # and urnAuthorityPath
+            owner_code = schools.school_info[
+                record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['owner_code']
+            billing_code = schools.school_info[
+                record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['billing_code']
+            urn_authority_path = schools.school_info[
+                record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['urn_authority_path']
         submission_dir = os.path.join(data_dir,
                                       record[mongo_util.FIELD_DIRECTORY_ID])
         zip_file = None

--- a/etd/alma_monitor.py
+++ b/etd/alma_monitor.py
@@ -269,7 +269,7 @@ class AlmaMonitor():
             owner_code = "HUL.TEST"
             billing_code = "HUL.TEST.BILL_0001"
             urn_authority_path = "HUL.TEST"
-        else:    
+        else:
             # Use schools.py to pull owner code, billing code,
             # and urnAuthorityPath
             owner_code = schools.school_info[
@@ -277,7 +277,8 @@ class AlmaMonitor():
             billing_code = schools.school_info[
                 record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['billing_code']
             urn_authority_path = schools.school_info[
-                record[mongo_util.FIELD_SCHOOL_ALMA_DROPBOX]]['urn_authority_path']
+                record[mongo_util.
+                       FIELD_SCHOOL_ALMA_DROPBOX]]['urn_authority_path']
         submission_dir = os.path.join(data_dir,
                                       record[mongo_util.FIELD_DIRECTORY_ID])
         zip_file = None


### PR DESCRIPTION
**Uses HUL.TEST for int testing regardless of **
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-324

# How should this be tested?

Use the etd-integration-test call to generate  and deposit a batch.  Batch should have owner and billing for HUL.TEST
Dev already tested.  Link to kick off test: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/alma_monitor_service

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no
