### PR TITLE
ETD 281: Prepare for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ DIMS_HEALTHCHECK_URL=
 CONSUME_QUEUE_NAME: in_alma_dropbox
 PUBLISH_QUEUE_NAME: etd_ingested_into_drs
 BROKER_URL= "ampqs://un:pw@mybroker.com:5671"
-JAEGER_NAME="http://localhost:4317"
+JAEGER_NAME="http://jaeger_dashboard:4317/"
 JAEGER_SERVICE_NAME=ETD
 
 HEARTBEAT_FILE=/tmp/worker_heartbeat

--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -16,7 +16,8 @@ def configure_logger():  # pragma: no cover
     log_file_path = os.getenv("LOGFILE_PATH",
                               "/home/etdadm/logs/etd_alma_monitor")
     formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - ' +
+                '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)


### PR DESCRIPTION
** Prepare for production.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-281

# What does this Pull Request do?
Adds method names, class names, and line numbers to log entries.

# How should this be tested?

## Local setup
    
1. Make a copy of the .env.example to .env and modify the user and password variables.

2. Start the container
    
```
docker-compose -f docker-compose-local.yml up -d --build --force-recreate
```

## Testing

1. Start the container up as described in the <b>Local Setup</b> instructions.

2. Exec into the container:

```
docker exec -it etd-alma-monitor-service bash
```

3. Run the tests

```
pytest
```
4. check the logs:
```
cd logs/etd; tail -f <CONTAINER_ID>_console_<TIMESTAMP>.log
```

you should see output similar to this:
```
23-12-14 23:57:01,968 - etd_alma_monitor - INFO - [alma_monitor.py:poll_for_alma_submissions:110] - Starting poll for alma submissions
2023-12-14 23:57:02,101 - etd_alma_monitor - DEBUG - [tasks.py:invoke_hello_world:188] - processing id: 30522803
2023-12-14 23:57:02,121 - etd_alma_monitor - DEBUG - [tasks.py:invoke_hello_world:190] - FEATURE FLAGS FOUND
2023-12-14 23:57:02,137 - etd_alma_monitor - DEBUG - [tasks.py:invoke_hello_world:191] - {'dash_feature_flag': 'off', 'alma_feature_flag': 'off', 'send_to_drs_feature_flag': 'off', 'drs_holding_record_feature_flag': 'off'}
```
if you do, then the test was successful.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
