### PR TITLE
Etd 347

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -166,11 +166,6 @@ def monitor_alma_and_invoke_dims(json_message):
             # No feature flags so do hello world for now
             return invoke_hello_world(json_message)
 
-        current_span.add_event("to next queue")  # pragma: no cover, tracing is not being tested # noqa: E501
-        app.send_task("etd-alma-drs-holding-service.tasks.add_holdings",
-                      args=[new_message], kwargs={},
-                      queue=os.getenv('PUBLISH_QUEUE_NAME'))  # pragma: no cover, does not reach this for unit testing # noqa: E501
-
 
 # To be removed when real logic takes its place
 @tracer.start_as_current_span("invoke_hello_world_alma_monitor")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -98,7 +98,7 @@ def monitor_alma_and_invoke_dims(json_message):
     # 3. If records are in Alma, call etd/alma_monitor.update_alma_status
     # 4. Invoke DIMS (call etd/alma_monitor.invoke_dims)
 
-    with tracer.start_as_current_span("Initialized ALMA Monitor / DRS") \
+    with tracer.start_as_current_span("Initialized ALMA Monitor") \
             as current_span:
         new_message = json_message
         carrier = {}


### PR DESCRIPTION
**Remove message passing, change tracing text.**
* * *

**JIRA Ticket**: [(link)](https://at-harvard.atlassian.net/browse/ETD-347)


# What does this Pull Request do?
This pr removes the message that had been passed to drs holdings, that is actually handled by dims. Hence, the tracing only shows alma monitor, not also drs holdings; drs holdings is a separate trace

# How should this be tested?

Deploy to dev (done)
Run the dev itest for monitor:

Run dev tracing
http://ltsds-cloud-dev-1.lib.harvard.edu:16686/

The alma monitor trace will no longer have drs holding, and the text at the top will say:
ETD: Initialized ALMA Monitor

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
