### PR TITLE
parse log backup count to int

### DIFF
--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -4,7 +4,7 @@ import os
 import socket
 from datetime import datetime
 
-LOG_FILE_BACKUP_COUNT = os.getenv('LOG_FILE_BACKUP_COUNT')
+LOG_FILE_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUP_COUNT', '30'))
 LOG_ROTATION = "midnight"
 
 container_id = socket.gethostname()


### PR DESCRIPTION
**Fix logging parse error..**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-396

# What does this Pull Request do?
This pr fixes error in pulling backupCount from the env file, needs to be parsed to int. 

# How should this be tested?

(DONE) Deploy to dev and confirm docker comes up without error, with output from the alma montor test:
https://ltsds-cloud-dev-1.lib.harvard.edu:10610/alma_monitor_service

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
